### PR TITLE
configurable via env

### DIFF
--- a/config/failed-job-monitor.php
+++ b/config/failed-job-monitor.php
@@ -24,10 +24,10 @@ return [
     /*
      * The channels to which the notification will be sent.
      */
-    'channels' => ['mail', 'slack'],
+    'channels' =>  explode(',', env('FAILED_JOB_CHANNELS', 'mail,slack')),
 
     'mail' => [
-        'to' => ['email@example.com'],
+        'to' => explode(',', env('FAILED_JOB_EMAILS', 'email@example.com')),
     ],
 
     'slack' => [


### PR DESCRIPTION
hi
On this PR This allows configuring channels and email recipients via .env instead of changing config files directly.

- Read notification channels from FAILED_JOB_CHANNELS (comma‑separated, default: mail, slack)
- Read mail recipients from FAILED_JOB_EMAILS (comma‑separated)
