### PR TITLE
Add ability to disable failed job monitor via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,23 @@ php artisan vendor:publish --tag=failed-job-monitor-config
 
 This is the contents of the default configuration file.  Here you can specify the notifiable to which the notifications should be sent. The default notifiable will use the variables specified in this config file.
 
+Add these variables to your `.env` file:
+
+```env
+# Spatie Laravel-failed-job-monitor
+FAILED_JOB_MONITOR_ENABLED=true
+FAILED_JOB_CHANNELS=mail,slack
+FAILED_JOB_EMAILS=email@example.com
+FAILED_JOB_SLACK_WEBHOOK_URL=
+```
+
 ```php
 return [
+
+    /**
+     * Whether the failed job monitor is enabled.
+     */
+    'enabled' => env('FAILED_JOB_MONITOR_ENABLED', true),
 
     /**
      * The notification that will be sent when a job fails.
@@ -65,10 +80,10 @@ return [
     /**
      * The channels to which the notification will be sent.
      */
-    'channels' => ['mail', 'slack'],
+    'channels' => explode(',', env('FAILED_JOB_CHANNELS', 'mail,slack')),
 
     'mail' => [
-        'to' => ['email@example.com'],
+        'to' => explode(',', env('FAILED_JOB_EMAILS', 'email@example.com')),
     ],
 
     'slack' => [
@@ -78,6 +93,14 @@ return [
 ``` 
 
 ## Configuration
+
+### Enabling or disabling the monitor
+
+By default, the failed job monitor is enabled. To disable notifications (e.g., in local development), set `FAILED_JOB_MONITOR_ENABLED=false` in your `.env` file:
+
+```env
+FAILED_JOB_MONITOR_ENABLED=false
+```
 
 ### Customizing the notification
  

--- a/config/failed-job-monitor.php
+++ b/config/failed-job-monitor.php
@@ -3,6 +3,12 @@
 return [
 
     /*
+     * Whether the failed job monitor is enabled. Set to false in your .env
+     * (FAILED_JOB_MONITOR_ENABLED=false) to disable notifications.
+     */
+    'enabled' => env('FAILED_JOB_MONITOR_ENABLED', true),
+
+    /*
      * The notification that will be sent when a job fails.
      */
     'notification' => \Spatie\FailedJobMonitor\Notification::class,

--- a/src/FailedJobNotifier.php
+++ b/src/FailedJobNotifier.php
@@ -11,6 +11,10 @@ class FailedJobNotifier
 {
     public function register(): void
     {
+        if (! config('failed-job-monitor.enabled', true)) {
+            return;
+        }
+
         app(QueueManager::class)->failing(function (JobFailed $event) {
             $notifiable = app(config('failed-job-monitor.notifiable'));
 

--- a/tests/FailedJobMonitorTest.php
+++ b/tests/FailedJobMonitorTest.php
@@ -54,3 +54,7 @@ it('filters out notifications when the notificationFilter returns `false`', func
 
     NotificationFacade::assertNotSentTo(new Notifiable(), Notification::class);
 });
+
+it('is enabled by default', function () {
+    expect(config('failed-job-monitor.enabled'))->toBeTrue();
+});


### PR DESCRIPTION
Hi,

Adds an `enabled` option driven by `FAILED_JOB_MONITOR_ENABLED` in `.env`. When set to `false`, the monitor stops registering and no notifications are sent.

Useful when connectivity (e.g., mail, Slack) is limited, like in Iran!
<img width="1338" height="90" alt="image" src="https://github.com/user-attachments/assets/e2c41ca6-37bf-4899-81be-7667013529fc" />
